### PR TITLE
[MAINT] test with 3.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# Documentation
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+-   package-ecosystem: github-actions
+    directory: /
+    schedule:
+        interval: monthly

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,16 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.x']
+        python-version: ['3.x', '3.13']
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,5 +39,5 @@ jobs:
     - name: Upload sample report
       uses: actions/upload-artifact@v4
       with:
-        name: report
+        name: report-${{ matrix.python-version }}
         path: tests/report

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         pytest tests
     - name: Upload sample report
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: report
         path: tests/report

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'pytest-reporter>=0.4.0',
         'Jinja2',
         'ansi2html>=1.3.0',
-        'htmlmin',
+        'htmlmin2',
         'docutils',
     ],
     classifiers=[


### PR DESCRIPTION
- closes #31 

- runs tests explicitly with python 3.13
  - adapt name of uploaded artefacts to prevent name clashes
- change dependency htmlmin to htmlmin2
- bump version upload artefact action (CI was failing otherwise)
- add dependabot to keep actions up to date (may trigger a series of PR upon merge)